### PR TITLE
Load streamers in serial; handle rate limit

### DIFF
--- a/lib/Streamers.js
+++ b/lib/Streamers.js
@@ -104,7 +104,10 @@ export default class Streamers {
       };
     });
 
-    const promises = mergedStreamers.map(async (streamer) => {
+    const composedData = [];
+
+    // load streamers in serial rather than parallel to avoid overhwhelming the API
+    for (let streamer of mergedStreamers) {
       const vodData = await TwitchApi.getVodDataById(
         streamer.twitchData.id,
         accessToken.access_token,
@@ -115,14 +118,14 @@ export default class Streamers {
         accessToken.access_token,
       );
 
-      return {
+      composedData.push({
         ...streamer,
         streamData,
         vodData,
-      };
-    });
+      });
+    }
 
-    return await Promise.all(promises);
+    return composedData;
   }
 
   static async callContentful(query) {

--- a/lib/Twitch.js
+++ b/lib/Twitch.js
@@ -84,7 +84,7 @@ export default class TwitchApi {
 
         // temporarily back off the API when rate limiting response is returned
         const refreshWhen = parseInt(response.headers.get("Ratelimit-Reset"));
-        const timeToWait = refreshWhen - Math.ceil(Date.now() / 1000);
+        const timeToWait = refreshWhen - Math.floor(Date.now() / 1000);
         console.warn(`Rate limited for ${timeToWait} seconds`);
         await waitFor(timeToWait);
       }

--- a/lib/Twitch.js
+++ b/lib/Twitch.js
@@ -1,3 +1,5 @@
+import { waitFor } from "./Utils";
+
 export default class TwitchApi {
   static getFetchOptions(accessToken) {
     return {
@@ -72,7 +74,21 @@ export default class TwitchApi {
 
   static async call(url, accessToken) {
     try {
-      const response = await fetch(url, TwitchApi.getFetchOptions(accessToken));
+      let response;
+
+      while (true) {
+        response = await fetch(url, TwitchApi.getFetchOptions(accessToken));
+
+        if (response.status != 429)
+          break;
+
+        // temporarily back off the API when rate limiting response is returned
+        const refreshWhen = parseInt(response.headers.get("Ratelimit-Reset"));
+        const timeToWait = refreshWhen - Math.ceil(Date.now() / 1000);
+        console.warn(`Rate limited for ${timeToWait} seconds`);
+        await waitFor(timeToWait);
+      }
+
       const responseJson = await response.json();
       return responseJson.data;
     } catch (error) {

--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -21,3 +21,7 @@ export function sortStreamers(a, b) {
     return 0;
   }
 }
+
+export async function waitFor(seconds) {
+  return await new Promise(res => setTimeout(res, seconds * 1000));
+}


### PR DESCRIPTION
There's still some parallel faffery happening further up in the stack, I'm fairly certain, but this seems to do a halfway decent job of handling rate limits in the Twitch API.