### PR TITLE
Revert "Load streamers in serial; handle rate limit"

### DIFF
--- a/lib/Streamers.js
+++ b/lib/Streamers.js
@@ -104,10 +104,7 @@ export default class Streamers {
       };
     });
 
-    const composedData = [];
-
-    // load streamers in serial rather than parallel to avoid overhwhelming the API
-    for (let streamer of mergedStreamers) {
+    const promises = mergedStreamers.map(async (streamer) => {
       const vodData = await TwitchApi.getVodDataById(
         streamer.twitchData.id,
         accessToken.access_token,
@@ -118,14 +115,14 @@ export default class Streamers {
         accessToken.access_token,
       );
 
-      composedData.push({
+      return {
         ...streamer,
         streamData,
         vodData,
-      });
-    }
+      };
+    });
 
-    return composedData;
+    return await Promise.all(promises);
   }
 
   static async callContentful(query) {

--- a/lib/Twitch.js
+++ b/lib/Twitch.js
@@ -1,5 +1,3 @@
-import { waitFor } from "./Utils";
-
 export default class TwitchApi {
   static getFetchOptions(accessToken) {
     return {
@@ -74,21 +72,7 @@ export default class TwitchApi {
 
   static async call(url, accessToken) {
     try {
-      let response;
-
-      while (true) {
-        response = await fetch(url, TwitchApi.getFetchOptions(accessToken));
-
-        if (response.status != 429)
-          break;
-
-        // temporarily back off the API when rate limiting response is returned
-        const refreshWhen = parseInt(response.headers.get("Ratelimit-Reset"));
-        const timeToWait = refreshWhen - Math.floor(Date.now() / 1000);
-        console.warn(`Rate limited for ${timeToWait} seconds`);
-        await waitFor(timeToWait);
-      }
-
+      const response = await fetch(url, TwitchApi.getFetchOptions(accessToken));
       const responseJson = await response.json();
       return responseJson.data;
     } catch (error) {

--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -21,7 +21,3 @@ export function sortStreamers(a, b) {
     return 0;
   }
 }
-
-export async function waitFor(seconds) {
-  return await new Promise(res => setTimeout(res, seconds * 1000));
-}


### PR DESCRIPTION
Reverts whitep4nth3r/womenwhostream.tech#4

ISR requests time out after 10 seconds. As a result, ISR fails consistently in production when we are instructed to wait for 60 seconds to avoid limits.